### PR TITLE
opt to change executor pod name (current "docker")

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ If the command is not specified, falls back to the `sh` command.
 
 **Flags**
 
-| Name      | Shorthand | Default | Usage                                                                     |
-|-----------|-----------|---------|---------------------------------------------------------------------------|
-| user      | -u        | root    | Username or UID.                                                          |
-| container | -c        |         | Container name. If omitted, the first container in the pod will be chosen |
+| Name      | Shorthand | Default   | Usage                                                                     |
+|-----------|-----------|---------- |---------------------------------------------------------------------------|
+| user      | -u        | root      | Username or UID.                                                          |
+| container | -c        |           | Container name. If omitted, the first container in the pod will be chosen |
+| name      | -o        | exec-user | Name for new exec-user pod to avoid `pods "exec-user" already exists`     |                           | 
 
 ## Examples
 

--- a/exec-user/exec-user.sh
+++ b/exec-user/exec-user.sh
@@ -2,6 +2,8 @@
 
 POD=${1}
 COMMAND=${2:-sh}
+NEW_POD_NAME=${KUBECTL_PLUGINS_LOCAL_FLAG_NAME:-exec-user-${POD}}
+NEW_POD_NAME=${NEW_POD_NAME:0:63}  # max len allowed
 
 KUBECTL=${KUBECTL_PLUGINS_CALLER}
 NAMESPACE=${KUBECTL_PLUGINS_CURRENT_NAMESPACE}
@@ -61,4 +63,4 @@ read -r -d '' OVERRIDES <<EOF
 }
 EOF
 
-eval kubectl run -it --rm --restart=Never --image=docker --overrides="'${OVERRIDES}'" docker
+eval kubectl run --namespace=${NAMESPACE} -it --rm --restart=Never --image=docker --overrides="'${OVERRIDES}'" ${NEW_POD_NAME}

--- a/exec-user/plugin.yaml
+++ b/exec-user/plugin.yaml
@@ -12,3 +12,6 @@ flags:
   - name: "container"
     shorthand: "c"
     desc: "Container name. If omitted, the first container in the pod will be chosen"
+  - name: "name"
+    shorthand: "o"
+    desc: "Name for new exec-user pod. If omitted it will use exec-user + $POD"


### PR DESCRIPTION
- add -o (to override) name `exec-user-$POD`:63. Note: `n` shorthand is not available.
- create new exec-user pod in same `KUBECTL_PLUGINS_CURRENT_NAMESPACE`