### PR TITLE
"USER" appears to be a reserved word

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ If the command is not specified, falls back to the `sh` command.
 
 **Flags**
 
-| Name      | Shorthand | Default   | Usage                                                                     |
-|-----------|-----------|---------- |---------------------------------------------------------------------------|
-| user      | -u        | root      | Username or UID.                                                          |
-| container | -c        |           | Container name. If omitted, the first container in the pod will be chosen |
-| name      | -o        | exec-user | Name for new exec-user pod to avoid `pods "exec-user" already exists`     |                           | 
+| Name       | Shorthand | Default   | Usage                                                                     |
+|------------|-----------|-----------|---------------------------------------------------------------------------|
+| targetuser | -u        | root      | Username or UID.                                                          |
+| container  | -c        |           | Container name. If omitted, the first container in the pod will be chosen |
+| name       | -o        | exec-user | Name for new exec-user pod to avoid `pods "exec-user" already exists`     |
 
 ## Examples
 

--- a/exec-user/exec-user.sh
+++ b/exec-user/exec-user.sh
@@ -7,7 +7,7 @@ NEW_POD_NAME=${NEW_POD_NAME:0:63}  # max len allowed
 
 KUBECTL=${KUBECTL_PLUGINS_CALLER}
 NAMESPACE=${KUBECTL_PLUGINS_CURRENT_NAMESPACE}
-USER=${KUBECTL_PLUGINS_LOCAL_FLAG_USER}
+TARGETUSER=${KUBECTL_PLUGINS_LOCAL_FLAG_TARGETUSER}
 export CONTAINER=${KUBECTL_PLUGINS_LOCAL_FLAG_CONTAINER}
 
 NODENAME=$( $KUBECTL --namespace ${NAMESPACE} get pod ${POD} -o go-template='{{.spec.nodeName}}' )
@@ -35,7 +35,7 @@ read -r -d '' OVERRIDES <<EOF
                   "exec",
                   "-it",
                   "-u",
-                  "${USER}",
+                  "${TARGETUSER}",
                   "${CONTAINERID}",
                   "${COMMAND}"
                 ],

--- a/exec-user/plugin.yaml
+++ b/exec-user/plugin.yaml
@@ -5,7 +5,7 @@ longDesc: >
 example: ""
 command: "./exec-user.sh"
 flags:
-  - name: "user"
+  - name: "targetuser"
     shorthand: "u"
     desc: "Username or UID. If omitted, will use root"
     defValue: "root"


### PR DESCRIPTION
I added an `env` to the script for debugging, because of #2 which is an issue I had trouble with too, and KUBECTL_PLUGINS_LOCAL_FLAG_USER is apparently never set no matter how you call the plugin, but if I change the flag name to "targetuser" then the -u short version also works.